### PR TITLE
Add scm-source to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM registry.opensource.zalan.do/stups/openjdk:8-26
-RUN mkdir /usr/pazuzu-ui
-COPY ./target/pazuzu-ui.jar /usr/pazuzu-ui
-WORKDIR /usr/pazuzu-ui
+COPY ./target/pazuzu-ui.jar /
+COPY scm-source.json /
 EXPOSE 8080
 CMD ["java", "-jar", "pazuzu-ui.jar"]


### PR DESCRIPTION
Add scm-source to Dockerfile and simplify Docker build.